### PR TITLE
Fix: Anypoint MQ Binding rules emptiness

### DIFF
--- a/anypoint/resource_ame_binding.go
+++ b/anypoint/resource_ame_binding.go
@@ -487,6 +487,10 @@ func resourceAMEBindingRulesDelete(ctx context.Context, d *schema.ResourceData, 
 func newAMEBindingRuleBody(d *schema.ResourceData) *ame_binding.AMEBindingRuleBody {
 	rules := extractAMEBindingRules(d)
 
+	if rules == nil {
+		return nil
+	}
+
 	body := ame_binding.NewAMEBindingRuleBody()
 	list := make([]map[string]interface{}, len(rules))
 


### PR DESCRIPTION
fixes issue where not having rules in binding triggers empty request and therefore an error with platform

```json
{
   "status" : "failure",
   "statusMessage" : "Routing rules cannot be empty."
}
```